### PR TITLE
Adding realized P/L value and % in the second table

### DIFF
--- a/lib/compute_breakdowns.js
+++ b/lib/compute_breakdowns.js
@@ -51,10 +51,10 @@ var ComputeBreakdowns = {
       if (key in this.breakdown_totals) {
         this.breakdown_totals[key].total_value += stock_summary.total_value;
         this.breakdown_totals[key].unrealized_pl += stock_summary.unrealized_pl;
-        if(!isNaN(stock_summary.realized_pl)){
-          if(("realized_pl" in this.breakdown_totals[key])){
+        if (!isNaN(stock_summary.realized_pl)){
+          if (("realized_pl" in this.breakdown_totals[key])){
             this.breakdown_totals[key].realized_pl += stock_summary.realized_pl;
-          } else if(!("realized_pl" in this.breakdown_totals[key])) {
+          } else {
             this.breakdown_totals[key].realized_pl = stock_summary.realized_pl;
           }
         }
@@ -63,7 +63,7 @@ var ComputeBreakdowns = {
           total_value: stock_summary.total_value,
           unrealized_pl: stock_summary.unrealized_pl,
         };
-        if(!isNaN(stock_summary.realized_pl)){
+        if (!isNaN(stock_summary.realized_pl)){
           this.breakdown_totals[key].realized_pl = stock_summary.realized_pl;
         }
       }

--- a/lib/compute_breakdowns.js
+++ b/lib/compute_breakdowns.js
@@ -62,7 +62,7 @@ var ComputeBreakdowns = {
         this.breakdown_totals[key] = {
           total_value: stock_summary.total_value,
           unrealized_pl: stock_summary.unrealized_pl,
-        };
+        }
         if (!isNaN(stock_summary.realized_pl)){
           this.breakdown_totals[key].realized_pl = stock_summary.realized_pl;
         }

--- a/lib/compute_breakdowns.js
+++ b/lib/compute_breakdowns.js
@@ -48,15 +48,25 @@ var ComputeBreakdowns = {
   },
 
   addToKey: function(key, stock_summary) {
-    if (key in this.breakdown_totals) {
-      this.breakdown_totals[key].total_value += stock_summary.total_value;
-      this.breakdown_totals[key].unrealized_pl += stock_summary.unrealized_pl;
-    } else {
-      this.breakdown_totals[key] = {
-        total_value: stock_summary.total_value,
-        unrealized_pl: stock_summary.unrealized_pl
-      };
-    }
+      if (key in this.breakdown_totals) {
+        this.breakdown_totals[key].total_value += stock_summary.total_value;
+        this.breakdown_totals[key].unrealized_pl += stock_summary.unrealized_pl;
+        if(!isNaN(stock_summary.realized_pl)){
+          if(("realized_pl" in this.breakdown_totals[key])){
+            this.breakdown_totals[key].realized_pl += stock_summary.realized_pl;
+          } else if(!("realized_pl" in this.breakdown_totals[key])) {
+            this.breakdown_totals[key].realized_pl = stock_summary.realized_pl;
+          }
+        }
+      } else {
+        this.breakdown_totals[key] = {
+          total_value: stock_summary.total_value,
+          unrealized_pl: stock_summary.unrealized_pl,
+        };
+        if(!isNaN(stock_summary.realized_pl)){
+          this.breakdown_totals[key].realized_pl = stock_summary.realized_pl;
+        }
+      }
   },
 
   getStockBreakdowns: function() {

--- a/lib/show_stock_breakdowns.js
+++ b/lib/show_stock_breakdowns.js
@@ -17,7 +17,7 @@ var ShowStockBreakdowns = {
 
   showTotalBreakdown: function(all_breakdown) {
     $('.stock-breakdowns-all').empty();
-    $('.stock-breakdowns-all').append("<tr><th>Total value</th><th>Unrealized P/L</th><th>Unrealized P/L %</th><th>Weighted cost</th><th>Weighted P/L %</th></tr>")
+    $('.stock-breakdowns-all').append("<tr><th>Total value</th><th>Unrealized P/L</th><th>Unrealized P/L %</th><th>Realized P/L</th><th>Realized P/L %<th>Weighted cost</th><th>Weighted P/L %</th></tr>")
     $('.stock-breakdowns-all').append(this.totalStats(all_breakdown));
   },
 
@@ -25,6 +25,8 @@ var ShowStockBreakdowns = {
     return "<tr><td>$" + MathHelpers.round2(all_breakdown.total_value) +
       "</td><td>$" + MathHelpers.round2(all_breakdown.unrealized_pl) +
       "</td><td>" + MathHelpers.round2(all_breakdown.unrealized_pl * 100 / (all_breakdown.total_value - all_breakdown.unrealized_pl)) + "%" +
+      "</td><td>$" + MathHelpers.round2(all_breakdown.realized_pl) +
+      "</td><td>" + MathHelpers.round2(all_breakdown.realized_pl * 100 / (all_breakdown.total_value - all_breakdown.unrealized_pl)) + "%" +
       "</td><td>$" + MathHelpers.round2(all_breakdown.weighted_cost) +
       "</td><td>" + MathHelpers.round2(all_breakdown.unrealized_pl * 100 / all_breakdown.weighted_cost) + "%" +
       "</td></tr>";


### PR DESCRIPTION
Now total realized profit or loss values and % are calculated and displayed in the second table.
![table2](https://cloud.githubusercontent.com/assets/20456492/22837177/15c36210-efc8-11e6-8a93-96894c6ff847.PNG)
