### PR TITLE
Converting plain objects to maps

### DIFF
--- a/lib/compute_breakdowns.js
+++ b/lib/compute_breakdowns.js
@@ -75,6 +75,6 @@ class ComputeBreakdowns {
           this.breakdown_totals.set(key, {realized_pl: stock_summary.realized_pl});
         }
       }
-      console.log(this.breakdown_totals);
+      console.log(this.breakdown_totals.get('ALL'));
   }
 };

--- a/lib/compute_breakdowns.js
+++ b/lib/compute_breakdowns.js
@@ -32,11 +32,8 @@ class ComputeBreakdowns {
     for (let [key] of this.breakdown_totals) {
       this.breakdown_totals.get(key).portion = this.breakdown_totals.get(key).total_value * 100.0 / this.total_portfolio_value;
     }
-    if (this.breakdown_totals[Constants.STOCK_ALL] === undefined){
-      this.breakdown_totals[Constants.STOCK_ALL] = { weighted_cost: this.total_weighted_cost };
-    } else {
-      this.breakdown_totals[Constants.STOCK_ALL].weighted_cost = this.total_weighted_cost;
-    }
+
+    this.breakdown_totals.get(Constants.STOCK_ALL).weighted_cost = this.total_weighted_cost;
   }
 
   _getMatchingKeys(stock) {

--- a/lib/compute_breakdowns.js
+++ b/lib/compute_breakdowns.js
@@ -29,8 +29,8 @@ class ComputeBreakdowns {
       }
     }
 
-    for (let symbol in this.breakdown_totals) {
-      this.breakdown_totals[symbol].portion = this.breakdown_totals[symbol].total_value * 100.0 / this.total_portfolio_value;
+    for (let [key] of this.breakdown_totals) {
+      this.breakdown_totals.get(key).portion = this.breakdown_totals.get(key).total_value * 100.0 / this.total_portfolio_value;
     }
     if (this.breakdown_totals[Constants.STOCK_ALL] === undefined){
       this.breakdown_totals[Constants.STOCK_ALL] = { weighted_cost: this.total_weighted_cost };
@@ -55,26 +55,25 @@ class ComputeBreakdowns {
   }
 
   _addToKey(key, stock_summary) {
-    // console.log(key);
       if (this.breakdown_totals.has(key)) {
-        // this.breakdown_totals[key].total_value += stock_summary.total_value;
-        // this.breakdown_totals[key].unrealized_pl += stock_summary.unrealized_pl;
+        this.breakdown_totals.get(key).total_value += stock_summary.total_value;
+        this.breakdown_totals.get(key).unrealized_pl += stock_summary.unrealized_pl;
         if (!isNaN(stock_summary.realized_pl)){
           if ('realized_pl' in this.breakdown_totals.get(key)){
             this.breakdown_totals.get(key).realized_pl += stock_summary.realized_pl;
           } else {
-            this.breakdown_totals[key].realized_pl = stock_summary.realized_pl;
+            this.breakdown_totals.get(key).realized_pl = stock_summary.realized_pl;
           }
         }
       } else {
-        // this.breakdown_totals.set(key, {
-        //   total_value: stock_summary.total_value,
-        //   unrealized_pl: stock_summary.unrealized_pl,
-        // });
+        this.breakdown_totals.set(key, {
+          total_value: stock_summary.total_value,
+          unrealized_pl: stock_summary.unrealized_pl
+        });
         if (!isNaN(stock_summary.realized_pl)){
-          this.breakdown_totals.set(key, {realized_pl: stock_summary.realized_pl});
+          this.breakdown_totals.get(key).realized_pl = stock_summary.realized_pl;
         }
       }
-      console.log(this.breakdown_totals.get('ALL'));
+      console.log(this.breakdown_totals);
   }
 };

--- a/lib/compute_breakdowns.js
+++ b/lib/compute_breakdowns.js
@@ -6,8 +6,8 @@ class ComputeBreakdowns {
     this.stock_summaries = stock_summaries;
     this.stocks = stocks;
 
-    this.stock_details = {};
-    this.breakdown_totals = {};
+    this.stock_details = new Map();
+    this.breakdown_totals = new Map();
   }
 
   getStockBreakdowns() {
@@ -17,11 +17,11 @@ class ComputeBreakdowns {
 
   _computeBreakdowns() {
     for (let stock of this.stocks) {
-      this.stock_details[stock.symbol] = stock;
+      this.stock_details.set(stock.symbol, stock);
     }
 
     for (let symbol in this.stock_summaries) {
-      let matching_keys = this._getMatchingKeys(this.stock_details[symbol])
+      let matching_keys = this._getMatchingKeys(this.stock_details.get(symbol))
       this.total_portfolio_value += this.stock_summaries[symbol].total_value;
       this.total_weighted_cost += this.stock_summaries[symbol].weighted_cost;
       for (let key of matching_keys) {
@@ -55,24 +55,26 @@ class ComputeBreakdowns {
   }
 
   _addToKey(key, stock_summary) {
-      if (key in this.breakdown_totals) {
-        this.breakdown_totals[key].total_value += stock_summary.total_value;
-        this.breakdown_totals[key].unrealized_pl += stock_summary.unrealized_pl;
+    // console.log(key);
+      if (this.breakdown_totals.has(key)) {
+        // this.breakdown_totals[key].total_value += stock_summary.total_value;
+        // this.breakdown_totals[key].unrealized_pl += stock_summary.unrealized_pl;
         if (!isNaN(stock_summary.realized_pl)){
-          if (("realized_pl" in this.breakdown_totals[key])){
-            this.breakdown_totals[key].realized_pl += stock_summary.realized_pl;
+          if ('realized_pl' in this.breakdown_totals.get(key)){
+            this.breakdown_totals.get(key).realized_pl += stock_summary.realized_pl;
           } else {
             this.breakdown_totals[key].realized_pl = stock_summary.realized_pl;
           }
         }
       } else {
-        this.breakdown_totals[key] = {
-          total_value: stock_summary.total_value,
-          unrealized_pl: stock_summary.unrealized_pl,
-        }
+        // this.breakdown_totals.set(key, {
+        //   total_value: stock_summary.total_value,
+        //   unrealized_pl: stock_summary.unrealized_pl,
+        // });
         if (!isNaN(stock_summary.realized_pl)){
-          this.breakdown_totals[key].realized_pl = stock_summary.realized_pl;
+          this.breakdown_totals.set(key, {realized_pl: stock_summary.realized_pl});
         }
       }
+      console.log(this.breakdown_totals);
   }
 };

--- a/lib/compute_breakdowns.js
+++ b/lib/compute_breakdowns.js
@@ -29,8 +29,8 @@ class ComputeBreakdowns {
       }
     }
 
-    for (let [key] of this.breakdown_totals) {
-      this.breakdown_totals.get(key).portion = this.breakdown_totals.get(key).total_value * 100.0 / this.total_portfolio_value;
+    for (let [key, value] of this.breakdown_totals) {
+      value.portion = value.total_value * 100.0 / this.total_portfolio_value;
     }
 
     this.breakdown_totals.get(Constants.STOCK_ALL).weighted_cost = this.total_weighted_cost;
@@ -52,25 +52,24 @@ class ComputeBreakdowns {
   }
 
   _addToKey(key, stock_summary) {
-      if (this.breakdown_totals.has(key)) {
-        this.breakdown_totals.get(key).total_value += stock_summary.total_value;
-        this.breakdown_totals.get(key).unrealized_pl += stock_summary.unrealized_pl;
-        if (!isNaN(stock_summary.realized_pl)){
-          if ('realized_pl' in this.breakdown_totals.get(key)){
-            this.breakdown_totals.get(key).realized_pl += stock_summary.realized_pl;
-          } else {
-            this.breakdown_totals.get(key).realized_pl = stock_summary.realized_pl;
-          }
-        }
-      } else {
-        this.breakdown_totals.set(key, {
-          total_value: stock_summary.total_value,
-          unrealized_pl: stock_summary.unrealized_pl
-        });
-        if (!isNaN(stock_summary.realized_pl)){
+    if (this.breakdown_totals.has(key)) {
+      this.breakdown_totals.get(key).total_value += stock_summary.total_value;
+      this.breakdown_totals.get(key).unrealized_pl += stock_summary.unrealized_pl;
+      if (!isNaN(stock_summary.realized_pl)){
+        if ('realized_pl' in this.breakdown_totals.get(key)){
+          this.breakdown_totals.get(key).realized_pl += stock_summary.realized_pl;
+        } else {
           this.breakdown_totals.get(key).realized_pl = stock_summary.realized_pl;
         }
       }
-      console.log(this.breakdown_totals);
+    } else {
+      this.breakdown_totals.set(key, {
+        total_value: stock_summary.total_value,
+        unrealized_pl: stock_summary.unrealized_pl
+      });
+      if (!isNaN(stock_summary.realized_pl)){
+        this.breakdown_totals.get(key).realized_pl = stock_summary.realized_pl;
+      }
+    }
   }
 };

--- a/lib/compute_next_trades.js
+++ b/lib/compute_next_trades.js
@@ -16,7 +16,7 @@ class ComputeNextTrades {
       return null;
     }
 
-    let current_value = this.stock_breakdowns.ALL.total_value;
+    let current_value = this.stock_breakdowns.get('ALL').total_value;
     let new_value = current_value + Constants.NEXT_AMOUNT;
 
     let value_to_buy = {ALL: 0.0};
@@ -25,8 +25,8 @@ class ComputeNextTrades {
       let desired_ratio = Constants.RATIOS[key];
       let desired_amount = new_value * desired_ratio / 100.0;
       let current_class_value = 0.0;
-      if (key in this.stock_breakdowns) {
-        current_class_value = this.stock_breakdowns[key].total_value;
+      if (this.stock_breakdowns.has(key)) {
+        current_class_value = this.stock_breakdowns.get(key).total_value;
       }
       let difference = desired_amount - current_class_value;
       if (difference > 0) {

--- a/lib/show_stock_breakdowns.js
+++ b/lib/show_stock_breakdowns.js
@@ -17,7 +17,7 @@ class ShowStockBreakdowns {
 
     this._addBreakdownGroup('combo', combined_breakdowns, this.stock_breakdowns);
 
-    this._showTotalBreakdown(this.stock_breakdowns[Constants.STOCK_ALL]);
+    this._showTotalBreakdown(this.stock_breakdowns.get(Constants.STOCK_ALL));
   }
 
   _showTotalBreakdown(all_breakdown) {
@@ -48,8 +48,8 @@ class ShowStockBreakdowns {
     }
 
     for (let key of keys) {
-      if (key in this.stock_breakdowns) {
-        $(table_class_name).append(this._breakdown_row(key, this.stock_breakdowns[key]));
+      if (this.stock_breakdowns.has(key)) {
+        $(table_class_name).append(this._breakdown_row(key, this.stock_breakdowns.get(key)));
       } else {
         let empty_row = `<tr><td>${key}</td><td>$0</td><td>$0</td><td>0%</td><td>0%</td>`
         if (table_type == 'combo') {


### PR DESCRIPTION
Converted `stock_details` and `breakdown_totals` from plain objects to Map(). Rewrote `compute_breakdowns`, `compute_next_trades` and `show_stock_breakdowns` logic to use the new Map object.